### PR TITLE
New release scripts

### DIFF
--- a/.travis/scripts/build.sh
+++ b/.travis/scripts/build.sh
@@ -49,6 +49,10 @@ elif [[ "${GIT_BRANCH}" = "master" ]]; then
         log "No release tag found on branch '${GIT_BRANCH}' for version '${VERSION}', running a test build."
         build_and_test
     fi
+elif [[ "${GIT_BRANCH:-}" = '' ]] && [[ "${TRAVIS_TAG:-}" = "${VERSION}" ]]; then
+    log "Publishing '${VERSION}' from tag (not merged back to master)."
+    validate_version "${VERSION}"
+    build_and_publish_artifacts
 else
     log "Not publishing '${VERSION}' from branch '${GIT_BRANCH}', running a test build."
     build_and_test

--- a/.travis/scripts/git-functions.sh
+++ b/.travis/scripts/git-functions.sh
@@ -6,6 +6,11 @@ declare -f debug > /dev/null || source "$(dirname $0)/logging.sh"
 # Script containing some handy git functions because CI (travis) runs on a detached HEAD
 #
 
+fix_travis_fetch() {
+    debug "Fixing broken 'git fetch' on travis..."
+    git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+}
+
 is_pull_request() {
     git ls-remote origin | grep $(git rev-parse HEAD) | grep "refs/pull/"
     return $?

--- a/.travis/scripts/maven-functions.sh
+++ b/.travis/scripts/maven-functions.sh
@@ -22,7 +22,7 @@ get_maven_version() {
 }
 
 set_maven_version() {
-    $(maven_command) --batch-mode versions:set versions:commit -DnewVersion="${1}"
+    $(maven_command) --batch-mode versions:set versions:commit -DnewVersion="${1}" >/dev/null || fatal "Could not set project version to ${1}!"
 }
 
 build_and_test_maven() {

--- a/.travis/scripts/versioning.sh
+++ b/.travis/scripts/versioning.sh
@@ -32,6 +32,16 @@ is_release_version() {
     fi
 }
 
+# Returns the major version for a valid semantic version string, undefined otherwise
+major_version_of() {
+    echo "${1}" | cut -d '.' -f 1
+}
+
+# Returns the major version for a valid semantic version string, undefined otherwise
+minor_version_of() {
+    echo "${1}" | cut -d '.' -f 2
+}
+
 # Returns the next snapshot version for the version specified in the first argument
 next_snapshot_version() {
     validate_version "${1:-}"


### PR DESCRIPTION
These support releases from old `develop` branches without merging
back to master.

Example:
Suppose the latest version is 2.0.1 (master), develop is 2.0.2-SNAPSHOT.
There is a `develop-v1` branch (naming matters!) where the 1.x versions
are maintained.

Pushing form develop-v1 to origin/release/1.2.3 branch will release
`1.2.3` without merging back to `master` or `develop` but merging back
to `develop-v1` while setting the next version to `1.2.4-SNAPSHOT` on
that branch.