### PR TITLE
Feature: A LazyValueMap behaving like a regular map with lazy values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,18 @@
                                 <artifactId>umldoclet</artifactId>
                                 <version>${umldoclet.version}</version>
                             </docletArtifact>
+                            <tags>
+                                <tag>
+                                    <name>implNote</name>
+                                    <placement>a</placement>
+                                    <head>Implementation Note:</head>
+                                </tag>
+                                <tag>
+                                    <name>implSpec</name>
+                                    <placement>a</placement>
+                                    <head>Implementation Requirements:</head>
+                                </tag>
+                            </tags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyUtils.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyUtils.java
@@ -1,0 +1,15 @@
+package nl.talsmasoftware.lazy4j;
+
+final class LazyUtils {
+    private LazyUtils() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    static <V> V getNullSafe(Lazy<V> lazy) {
+        return lazy == null ? null : lazy.get();
+    }
+
+    static <T> T getIfAvailableElseNull(Lazy<T> lazy) {
+        return lazy == null || !lazy.isAvailable() ? null : lazy.get();
+    }
+}

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyUtils.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018-2025 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.talsmasoftware.lazy4j;
 
 final class LazyUtils {

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -407,26 +407,6 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
     }
 
     /**
-     * Replaces the entry for the specified key only if currently mapped to the specified old value.
-     *
-     * <p>
-     * Comparison with {@code oldValue} uses causes eager evaluation of any existing lazy value for the specified key.
-     *
-     * @param key      key with which the specified value is associated.
-     * @param oldValue value expected to be currently associated with the specified key.
-     * @param newValue value to be associated with the specified key if the current value matches {@code oldValue}.
-     * @return {@code true} if the value was replaced, {@code false} otherwise.
-     */
-    @Override
-    public boolean replace(K key, V oldValue, V newValue) {
-        if (containsKey(key) && Objects.equals(oldValue, get(key))) {
-            put(key, newValue);
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * If the value for the specified key is present, computes a new mapping given the key and its current value.
      *
      * <p>

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -69,8 +69,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      * @see #LazyValueMap(Supplier)
      */
     public LazyValueMap(Map<K, V> toCopy) {
-        this();
-        putAll(toCopy);
+        this(() -> copyToLazyMap(toCopy));
     }
 
     /**
@@ -96,25 +95,81 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         this.delegate = requireNonNull(mapFactory.get(), "Backing map may not be <null>.");
     }
 
+    /**
+     * Returns a {@code Set} view of the mappings contained in this map.
+     *
+     * <p>
+     * The set supports mutation operations such as removal and {@link Map.Entry#setValue(Object)} calls
+     * <em>if</em> the backing map supports them.
+     *
+     * @return A {@code Set} view of the mapping entries contained in this map.
+     */
     @Override
     public Set<Entry<K, V>> entrySet() {
         return new LazyEntrySet<>(delegate.entrySet());
     }
 
+    /**
+     * Gets the value for the specified key, if it is already available.
+     *
+     * <p>
+     * Will return the evaluated value if:
+     * <ol>
+     *     <li>The map contains a lazy value for the specified key that has already been evaluated and is not {@code null}.
+     * </ol>
+     *
+     * <p>
+     * Will return {@link Optional#empty()} if:
+     * <ol>
+     *     <li>The map does not contain the specified key.
+     *     <li>The map contains a lazy value for the specified key that has not been evaluated yet.
+     *     <li>The map contains an evaluated value that is {@code null}.
+     * </ol>
+     *
+     * <p>
+     * Note that this method will <em>not</em> force the mapped value to be evaluated.
+     *
+     * @param key The key to get the value for, if already available.
+     * @return The value for the specified key, if already available, otherwise {@link Optional#empty()}.
+     * @see Lazy#getIfAvailable()
+     */
     public Optional<V> getIfAvailable(K key) {
         return Optional.ofNullable(getIfAvailableElseNull(delegate.get(key)));
     }
 
+    /**
+     * Gets the value for the specified key, forcing the lazy value to be evaluated if necessary.
+     *
+     * @param key the key whose associated value is to be returned
+     * @return The value for the specified key, or {@code null} if the map contains no mapping for the key.
+     * @see #getIfAvailable(Object)
+     */
     @Override
     public V get(Object key) {
         return getNullSafe(delegate.get(key));
     }
 
+    /**
+     * Puts the specified value for the specified key.
+     *
+     * <p>
+     * This value will <strong>not</strong> be lazy and will be available immediately.
+     *
+     * @param key   the key with which the specified value is to be associated.
+     * @param value the new value to be associated with the specified key.
+     * @return The previous value associated with key,  or {@code null} if there was no mapping for key.
+     * A null result can also indicate that <strong>the previous lazy value was not yet evaluated</strong>.
+     * @implNote This method will <strong>not</strong> eagerly evaluate the previous lazy value.
+     * So if the map contained a previous lazy value which was not yet evaluated, it will <strong>not</strong> evaluate it,
+     * but return {@code null} instead.
+     * @see #putLazy(Object, Supplier)
+     */
     @Override
     public V put(K key, V value) {
         return getIfAvailableElseNull(putLazy(key, Lazy.eager(value)));
     }
 
+    // TODO document and test from here!
     public Lazy<V> putLazy(K key, Supplier<V> valueSupplier) {
         return delegate.put(key, Lazy.of(valueSupplier));
     }
@@ -290,4 +345,16 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         }
     }
 
+    private static <K, V> Map<K, Lazy<V>> copyToLazyMap(Map<K, V> toCopy) {
+        if (toCopy instanceof LazyValueMap) { // Reuse lazy values if we can.
+            return new LinkedHashMap<>(((LazyValueMap<K, V>) toCopy).delegate);
+        }
+
+        // Otherwise, convert the actual values to (eager) Lazy instances.
+        Map<K, Lazy<V>> eagerCopy = new LinkedHashMap<>(toCopy.size());
+        for (Entry<K, V> entry : toCopy.entrySet()) {
+            eagerCopy.put(entry.getKey(), Lazy.eager(entry.getValue()));
+        }
+        return eagerCopy;
+    }
 }

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -134,7 +134,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      * @see Lazy#getIfAvailable()
      */
     public Optional<V> getIfAvailable(K key) {
-        return Optional.ofNullable(getIfAvailableElseNull(delegate.get(key)));
+        return Optional.ofNullable(getIfAvailableElseNull(getLazy(key)));
     }
 
     /**
@@ -143,10 +143,21 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      * @param key the key whose associated value is to be returned
      * @return The value for the specified key, or {@code null} if the map contains no mapping for the key.
      * @see #getIfAvailable(Object)
+     * @see #getLazy(Object)
      */
     @Override
     public V get(Object key) {
-        return getNullSafe(delegate.get(key));
+        return getNullSafe(getLazy(key));
+    }
+
+    /**
+     * Gets the lazy value for the specified key.
+     *
+     * @param key the key whose associated value is to be returned
+     * @return The lazy value for the specified key, or {@code null} if the map contains no mapping for the key.
+     */
+    public Lazy<V> getLazy(Object key) {
+        return delegate.get(key);
     }
 
     /**
@@ -158,10 +169,8 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      * @param key   the key with which the specified value is to be associated.
      * @param value the new value to be associated with the specified key.
      * @return The previous value associated with key,  or {@code null} if there was no mapping for key.
-     * A null result can also indicate that <strong>the previous lazy value was not yet evaluated</strong>.
-     * @implNote This method will <strong>not</strong> eagerly evaluate the previous lazy value.
-     * So if the map contained a previous lazy value which was not yet evaluated, it will <strong>not</strong> evaluate it,
-     * but return {@code null} instead.
+     * A null result can also indicate that <strong>the previous lazy value was not yet available</strong>.
+     * @implNote The returned previous mapping, if any, is <em>not</em> eagerly evaluated by this method.
      * @see #putLazy(Object, Supplier)
      */
     @Override
@@ -169,16 +178,52 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         return getIfAvailableElseNull(putLazy(key, Lazy.eager(value)));
     }
 
-    // TODO document and test from here!
+    /**
+     * Associates the specified key with a lazily computed value.
+     *
+     * <p>
+     * The supplied {@link Supplier} will be evaluated at most once,
+     * the first time the value is required (e.g. via {@link #get(Object)} or by an operation that
+     * needs the concrete value).
+     *
+     * @param key           the key with which the specified lazy value is to be associated.
+     * @param valueSupplier supplier that provides the value when needed (required, non-{@code null}).
+     * @return the previous value associated with the key, or {@code null} if there was no mapping.
+     * @implNote The returned previous mapping, if any, is <em>not</em> eagerly evaluated by this method.
+     * @see #put(Object, Object)
+     * @see Lazy#of(Supplier)
+     */
     public Lazy<V> putLazy(K key, Supplier<V> valueSupplier) {
         return delegate.put(key, Lazy.of(valueSupplier));
     }
 
+    /**
+     * Returns a {@link Collection} view of the lazy values contained in this map.
+     *
+     * @return The lazy values contained in this map.
+     * @see #values()
+     */
+    public Collection<Lazy<V>> lazyValues() {
+        return delegate.values();
+    }
+
+    /**
+     * Returns {@code true} if this map maps one or more keys to the specified value.
+     *
+     * <p>
+     * This implementation performs a two-pass check to minimize unnecessary evaluations:
+     * it first inspects already available values, and only evaluates unavailable values on a second pass
+     * if no match was found. This means calling this method may cause evaluation of previously
+     * unavailable lazy values.
+     *
+     * @param value value whose presence in this map is to be tested.
+     * @return {@code true} if this map maps one or more keys to the specified value.
+     */
     @Override
     public boolean containsValue(Object value) {
         // First pass, check available values.
         List<Lazy<V>> unavailableOnFirstPass = new ArrayList<>();
-        for (Lazy<V> lazyValue : delegate.values()) {
+        for (Lazy<V> lazyValue : lazyValues()) {
             if (!lazyValue.isAvailable()) {
                 if (unavailableOnFirstPass != null) {
                     if (unavailableOnFirstPass.size() < 10000) {
@@ -192,7 +237,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
             }
         }
         // Second pass, check the values that were not yet available.
-        for (Lazy<V> lazyValue : unavailableOnFirstPass != null ? unavailableOnFirstPass : delegate.values()) {
+        for (Lazy<V> lazyValue : unavailableOnFirstPass != null ? unavailableOnFirstPass : lazyValues()) {
             if (Objects.equals(value, lazyValue.get())) {
                 return true;
             }
@@ -200,58 +245,178 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         return false;
     }
 
+    /**
+     * Returns the number of key-value mappings in this map.
+     *
+     * @return the number of key-value mappings in this map.
+     */
     @Override
     public int size() {
         return delegate.size();
     }
 
+    /**
+     * Returns {@code true} if this map contains a mapping for the specified key.
+     *
+     * <p>
+     * This operation does not evaluate the associated value, if any.
+     *
+     * @param key key whose presence in this map is to be tested.
+     * @return {@code true} if this map contains a mapping for the specified key.
+     */
     @Override
     public boolean containsKey(Object key) {
         return delegate.containsKey(key);
     }
 
+    /**
+     * Removes the mapping for a key from this map if it is present.
+     *
+     * <p>
+     * The removed value is returned only if it had already been evaluated; otherwise {@code null} is returned
+     * without forcing evaluation.
+     *
+     * @param key key whose mapping is to be removed from the map.
+     * @return the previously associated value if it was available, or {@code null} otherwise.
+     */
     @Override
     public V remove(Object key) {
         return getIfAvailableElseNull(delegate.remove(key));
     }
 
+    /**
+     * Removes all the mappings from this map.
+     *
+     * <p>
+     * After this call returns, the map will be empty.
+     */
     @Override
     public void clear() {
         delegate.clear();
     }
 
+    /**
+     * Returns a {@link Set} view of the keys contained in this map.
+     *
+     * <p>
+     * The returned set is backed by the map; changes to the set are reflected in the map, and vice-versa.
+     *
+     * @return a set view of the keys contained in this map.
+     */
     @Override
     public Set<K> keySet() {
         return delegate.keySet();
     }
 
+    /**
+     * If the specified key is not already associated with a value, attempts to compute its value using
+     * the given mapping function and enters it into this map.
+     *
+     * <p>
+     * This forces the computation of an existing lazy value, if necessary.
+     *
+     * @param key             key with which the computed value is to be associated.
+     * @param mappingFunction the function to compute a value.
+     * @return the current (existing or computed) value associated with the specified key, or {@code null} if none.
+     * @see #computeIfAbsentLazy(Object, Function)
+     */
     @Override
     public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
         return getNullSafe(computeIfAbsentLazy(key, mappingFunction));
     }
 
+    /**
+     * Lazy variant of {@link #computeIfAbsent(Object, Function)}.
+     *
+     * <p>
+     * Stores a lazy computation for the value if the key is not present.
+     * The mapping function itself is not executed until the value is required for the first time.
+     *
+     * @param key             key with which the computed value is to be associated.
+     * @param mappingFunction the function to compute a value.
+     * @return the lazy value associated with the specified key (existing or newly created).
+     */
     public Lazy<V> computeIfAbsentLazy(K key, Function<? super K, ? extends V> mappingFunction) {
         return delegate.computeIfAbsent(key, k -> Lazy.of(() -> mappingFunction.apply(k)));
     }
 
+    /**
+     * If the specified key is not already associated with a value, associate it with the given value.
+     *
+     * <p>
+     * The provided value is stored eagerly. If a mapping already exists, that existing value is left
+     * untouched and returned if it was already available; otherwise {@code null} is returned without
+     * forcing evaluation of the existing lazy value.
+     *
+     * @param key   key with which the specified value is to be associated.
+     * @param value value to associate with the specified key if absent.
+     * @return the previous value if present and already available; otherwise {@code null}.
+     * @see #putIfAbsentLazy(Object, Supplier)
+     */
     @Override
     public V putIfAbsent(K key, V value) {
         return getIfAvailableElseNull(putIfAbsentLazy(key, Lazy.eager(value)));
     }
 
+    /**
+     * Lazy variant of {@link #putIfAbsent(Object, Object)}.
+     *
+     * <p>
+     * If the key is absent, associates it with a lazy value constructed from the given supplier.
+     * If a mapping already exists, it is returned and not evaluated by this method.
+     *
+     * @param key   key with which the specified lazy value is to be associated.
+     * @param value supplier of the value to associate if absent (required, non-{@code null}).
+     * @return the existing lazy value if present, or {@code null} if the association was added.
+     */
     public Lazy<V> putIfAbsentLazy(K key, Supplier<V> value) {
         return delegate.putIfAbsent(key, Lazy.of(value));
     }
 
+    /**
+     * Replaces the entry for the specified key only if it is currently mapped to some value.
+     *
+     * <p>
+     * The new value is stored eagerly. The previously associated value is returned only if it had
+     * already been evaluated; otherwise {@code null} is returned without forcing evaluation.
+     *
+     * @param key   key with which the specified value is associated.
+     * @param value value to be associated with the specified key.
+     * @return the previous value if present and available; otherwise {@code null}.
+     * @see #replaceLazy(Object, Supplier)
+     */
     @Override
     public V replace(K key, V value) {
         return getIfAvailableElseNull(replaceLazy(key, Lazy.eager(value)));
     }
 
+    /**
+     * Lazy variant of {@link #replace(Object, Object)}.
+     *
+     * <p>
+     * Replaces the entry for the specified key only if it is currently mapped to some value,
+     * associating it with the given lazy supplier. The previous lazy value, if any, is returned
+     * without being evaluated by this method.
+     *
+     * @param key   key with which the specified lazy value is associated.
+     * @param value supplier of the new value (required, non-{@code null}).
+     * @return the previous lazy value associated with the key, or {@code null} if there was no mapping.
+     */
     public Lazy<V> replaceLazy(K key, Supplier<V> value) {
         return delegate.replace(key, Lazy.of(value));
     }
 
+    /**
+     * Replaces the entry for the specified key only if currently mapped to the specified old value.
+     *
+     * <p>
+     * Comparison with {@code oldValue} uses causes eager evaluation of any existing lazy value for the specified key.
+     *
+     * @param key      key with which the specified value is associated.
+     * @param oldValue value expected to be currently associated with the specified key.
+     * @param newValue value to be associated with the specified key if the current value matches {@code oldValue}.
+     * @return {@code true} if the value was replaced, {@code false} otherwise.
+     */
     @Override
     public boolean replace(K key, V oldValue, V newValue) {
         if (containsKey(key) && Objects.equals(oldValue, get(key))) {
@@ -261,33 +426,121 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         return false;
     }
 
+    /**
+     * If the value for the specified key is present, computes a new mapping given the key and its current value.
+     *
+     * <p>
+     * If the map contains a lazy value for the specified key,
+     * it will be eagerly evaluated and applied in the remapping function.
+     * Consider using {@link #computeIfPresentLazy(Object, BiFunction)} instead, to prevent eager evaluation.
+     *
+     * @param key               key with which the specified value is associated.
+     * @param remappingFunction the function to compute a value.
+     * @return the new value associated with the specified key, or {@code null} if none.
+     * @see #computeIfPresentLazy(Object, BiFunction)
+     */
     @Override
     public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
         return getNullSafe(computeIfPresentLazy(key, remappingFunction));
     }
 
+    /**
+     * Lazy variant of {@link #computeIfPresent(Object, BiFunction)}.
+     *
+     * <p>
+     * If a non-null mapping exists, stores a lazy remapping that invokes {@code remappingFunction}
+     * with the key and the evaluated current value when needed.
+     *
+     * @param key               key with which the specified value is associated.
+     * @param remappingFunction the function to compute a value.
+     * @return the new lazy value associated with the specified key, or {@code null} if none.
+     */
     public Lazy<V> computeIfPresentLazy(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
         return delegate.computeIfPresent(key, (k, v) -> Lazy.of(() -> remappingFunction.apply(k, getNullSafe(v))));
     }
 
+    /**
+     * Compute a mapping for the specified key and its current mapped value (or {@code null}
+     * if there is no current mapping).
+     *
+     * <p>
+     * If the map contains a lazy value for the specified key,
+     * it will be eagerly evaluated and applied in the remapping function.
+     * Consider using {@link #computeLazy(Object, BiFunction)} instead, to prevent eager evaluation.
+     *
+     * @param key               key with which the specified value is associated.
+     * @param remappingFunction the function to compute a value.
+     * @return the new value associated with the specified key, or {@code null} if none.
+     * @see #computeLazy(Object, BiFunction)
+     */
     @Override
     public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
         return getNullSafe(computeLazy(key, remappingFunction));
     }
 
+    /**
+     * Lazy variant of {@link #compute(Object, BiFunction)}.
+     *
+     * <p>
+     * Stores a lazy remapping that invokes {@code remappingFunction} with the key and the evaluated
+     * current value (which may be {@code null}), when needed.
+     *
+     * <p>
+     * The remapping function (and eager evaluation of the existing value) is applied lazily and will only be evaluated
+     * when the computed value is actually needed for the first time.
+     *
+     * @param key               key with which the specified value is associated.
+     * @param remappingFunction the function to compute a value.
+     * @return the new lazy value associated with the specified key.
+     */
     public Lazy<V> computeLazy(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
         return delegate.compute(key, (k, v) -> Lazy.of(() -> remappingFunction.apply(k, getNullSafe(v))));
     }
 
+    /**
+     * If the specified key is not already associated with a value, associates it with the given value.
+     * Otherwise, replaces the value with the result of the given remapping function.
+     *
+     * <p>
+     * The provided value is stored eagerly; the remapping function is applied lazily and will be evaluated
+     * when the merged value is actually needed.
+     *
+     * @param key               key with which the resulting value is to be associated.
+     * @param value             the value to use if absent.
+     * @param remappingFunction the function to recompute a value if present.
+     * @return the new value associated with the specified key, or {@code null} if none.
+     * @see #mergeLazy(Object, Supplier, BiFunction)
+     */
     @Override
     public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
         return getNullSafe(mergeLazy(key, Lazy.eager(value), remappingFunction));
     }
 
+    /**
+     * Lazy variant of {@link #merge(Object, Object, BiFunction)}.
+     *
+     * <p>
+     * If the key is absent, associates it with a lazy value from the given supplier. If present,
+     * associates it with a lazy value that lazily applies the {@code remappingFunction} to the
+     * existing and supplied values only when needed for the first time.
+     *
+     * @param key               key with which the resulting value is to be associated.
+     * @param value             supplier of the value to use if absent (required, non-{@code null}).
+     * @param remappingFunction the function to recompute a value if present.
+     * @return the new lazy value associated with the specified key.
+     * @throws NullPointerException if {@code value} is {@code null} (via {@link Lazy#of(Supplier)}).
+     */
     public Lazy<V> mergeLazy(K key, Supplier<V> value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
         return delegate.merge(key, Lazy.of(value), (v1, v2) -> Lazy.of(() -> remappingFunction.apply(getNullSafe(v1), getNullSafe(v2))));
     }
 
+    /**
+     * EntrySet that exposes {@code Map.Entry<K,V>} views while delegating to an underlying
+     * {@code Set<Entry<K, Lazy<V>>>}. Values are evaluated on access only where required.
+     *
+     * @param <K> key type.
+     * @param <V> value type.
+     */
     private static class LazyEntrySet<K, V> extends AbstractSet<Entry<K, V>> {
         private final Set<Entry<K, Lazy<V>>> delegateEntrySet;
 
@@ -322,6 +575,14 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         }
     }
 
+    /**
+     * Map.Entry wrapper that exposes an evaluated {@code V} view over an underlying
+     * {@code Entry<K, Lazy<V>>}. Setting a value replaces the underlying lazy value with
+     * an eager one for the provided value.
+     *
+     * @param <K> key type.
+     * @param <V> value type.
+     */
     private static final class LazyEntry<K, V> implements Entry<K, V> {
         private final Entry<K, Lazy<V>> delegateEntry;
 
@@ -345,6 +606,18 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         }
     }
 
+    /**
+     * Creates a {@code Map<K, Lazy<V>>} copy of the given {@code Map<K, V>}.
+     *
+     * <p>
+     * If the source map is already a {@code LazyValueMap}, its internal lazy values are reused
+     * without triggering evaluation. Otherwise, values are wrapped into eager {@link Lazy} instances.
+     *
+     * @param toCopy source map to copy from.
+     * @param <K>    key type.
+     * @param <V>    value type.
+     * @return a new {@link LinkedHashMap} containing lazy values that mirror the source contents.
+     */
     private static <K, V> Map<K, Lazy<V>> copyToLazyMap(Map<K, V> toCopy) {
         if (toCopy instanceof LazyValueMap) { // Reuse lazy values if we can.
             return new LinkedHashMap<>(((LazyValueMap<K, V>) toCopy).delegate);

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -110,34 +110,6 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
     }
 
     /**
-     * Gets the value for the specified key, if it is already available.
-     *
-     * <p>
-     * Will return the evaluated value if:
-     * <ol>
-     *     <li>The map contains a lazy value for the specified key that has already been evaluated and is not {@code null}.
-     * </ol>
-     *
-     * <p>
-     * Will return {@link Optional#empty()} if:
-     * <ol>
-     *     <li>The map does not contain the specified key.
-     *     <li>The map contains a lazy value for the specified key that has not been evaluated yet.
-     *     <li>The map contains an evaluated value that is {@code null}.
-     * </ol>
-     *
-     * <p>
-     * Note that this method will <em>not</em> force the mapped value to be evaluated.
-     *
-     * @param key The key to get the value for, if already available.
-     * @return The value for the specified key, if already available, otherwise {@link Optional#empty()}.
-     * @see Lazy#getIfAvailable()
-     */
-    public Optional<V> getIfAvailable(K key) {
-        return Optional.ofNullable(getIfAvailableElseNull(getLazy(key)));
-    }
-
-    /**
      * Gets the value for the specified key, forcing the lazy value to be evaluated if necessary.
      *
      * @param key the key whose associated value is to be returned

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -488,6 +488,25 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
     }
 
     /**
+     * Calculate the hashcode for this map.
+     *
+     * @return The hashcode for this map.
+     * @implNote To comply with the general {@link Map} contract, unfortunately this involves eagerly
+     * evaluating <strong>all</strong> lazy values currently contained in the map.
+     */
+    @Override
+    public int hashCode() {
+        // Calculate hashcode for our entries.
+        // Unfortunately this will involve eagerly evaluating all lazy values.
+        return super.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    /**
      * EntrySet that exposes {@code Map.Entry<K,V>} views while delegating to an underlying
      * {@code Set<Entry<K, Lazy<V>>>}. Values are evaluated on access only where required.
      *
@@ -556,6 +575,44 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         @Override
         public V setValue(V value) {
             return getIfAvailableElseNull(delegateEntry.setValue(Lazy.eager(value)));
+        }
+
+        /**
+         * Calculates the hashcode for this entry.
+         *
+         * @return The hashcode for this entry.
+         * @implNote This implementation is based on the {@link Map.Entry#hashCode()} contract.
+         * Unfortunately, that involves eagerly evaluating the value if it has not been evaluated yet.
+         */
+        @Override
+        public int hashCode() {
+            K key = getKey();
+            V value = getValue();
+            return (key == null ? 0 : key.hashCode()) ^ (value == null ? 0 : value.hashCode());
+        }
+
+        /**
+         * Compares this lazy entry to another object.
+         *
+         * @param other object to be compared for equality with this map entry
+         * @return whether the other object is also a map entry with equal keys and values.
+         */
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof Entry
+                    && Objects.equals(getKey(), ((Entry<?, ?>) other).getKey())
+                    && Objects.equals(getValue(), ((Entry<?, ?>) other).getValue()));
+        }
+
+        /**
+         * The string representation of lazy entries will <em>not</em> eagerly evaluate the underlying lazy value.
+         * Instead, the string representation of entry in the underlying map is returned.
+         *
+         * @return The string representation of the underlying entry.
+         */
+        @Override
+        public String toString() {
+            return delegateEntry.toString();
         }
     }
 

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -111,7 +111,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      * @return The lazy value for the specified key, or {@code null} if the map contains no mapping for the key.
      * @see #get(Object)
      */
-    public Lazy<V> getLazy(Object key) {
+    public Lazy<V> getLazy(K key) {
         return delegate.get(key);
     }
 
@@ -265,8 +265,9 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      * @see #getLazy(Object)
      */
     @Override
+    @SuppressWarnings("unchecked") // Necessary due to Map contract.
     public V get(Object key) {
-        return getNullSafe(getLazy(key));
+        return getNullSafe(getLazy((K) key));
     }
 
     /**
@@ -292,7 +293,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      *
      * <p>
      * This implementation performs a two-pass check to minimize unnecessary evaluations:
-     * it first inspects already available values, and only evaluates unavailable values on a second pass
+     * it first inspects already available values and only evaluates unavailable values on a second pass
      * if no match was found. This means calling this method may cause evaluation of previously
      * unavailable lazy values.
      *
@@ -368,7 +369,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      * Returns a {@link Set} view of the keys contained in this map.
      *
      * <p>
-     * The returned set is backed by the map; changes to the set are reflected in the map, and vice-versa.
+     * The returned set is backed by the map; changes to the set are reflected in the map, and vice versa.
      *
      * @return a set view of the keys contained in this map.
      */
@@ -608,9 +609,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
          */
         @Override
         public int hashCode() {
-            K key = getKey();
-            V value = getValue();
-            return (key == null ? 0 : key.hashCode()) ^ (value == null ? 0 : value.hashCode());
+            return Objects.hashCode(getKey()) ^ Objects.hashCode(getValue());
         }
 
         /**
@@ -628,7 +627,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
 
         /**
          * The string representation of lazy entries will <em>not</em> eagerly evaluate the underlying lazy value.
-         * Instead, the string representation of entry in the underlying map is returned.
+         * Instead, the string representation of a lazy map entry in the underlying map is returned.
          *
          * @return The string representation of the underlying entry.
          */

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -5,23 +5,80 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static java.util.Objects.requireNonNull;
 import static nl.talsmasoftware.lazy4j.LazyUtils.getIfAvailableElseNull;
 import static nl.talsmasoftware.lazy4j.LazyUtils.getNullSafe;
 
+/**
+ * A map that can store its values in a {@link Lazy} manner.
+ *
+ * <p>
+ * This has the advantage that while providing 'standard' {@link Map} features,
+ * unused values do not need to be evaluated.
+ *
+ * <p>
+ * The behaviour of this map depends on the delegate map it was {@link #LazyValueMap(Supplier) initialized} with.
+ * If the delegate map is mutable, the lazy map will be mutable as well.
+ * If the delegate map is sorted, the lazy map will be sorted as well.
+ * The {@link #LazyValueMap() default} and {@link #LazyValueMap(Map) copy} constructors create a lazy map
+ * that behaves like a {@link LinkedHashMap}.
+ *
+ * @param <K> The type of the keys in the map.
+ * @param <V> The type of the values in the map.
+ * @author Sjoerd Talsma
+ * @see Lazy
+ * @since 2.0.2
+ */
 public class LazyValueMap<K, V> extends AbstractMap<K, V> {
+    /**
+     * The delegate map containing the lazy values.
+     */
     private final Map<K, Lazy<V>> delegate;
 
+    /**
+     * Creates a new empty {@code LazyValueMap}, behaving like a {@link LinkedHashMap}.
+     *
+     * @see #LazyValueMap(Supplier)
+     */
     public LazyValueMap() {
         this(LinkedHashMap::new);
     }
 
+    /**
+     * Creates a new {@code LazyValueMap} with the same contents as the specified map.
+     *
+     * <p>
+     * The new map behaves like a {@link LinkedHashMap}.
+     *
+     * @param toCopy The map to copy the contents from.
+     * @see #LazyValueMap(Supplier)
+     */
     public LazyValueMap(Map<K, V> toCopy) {
         this();
         putAll(toCopy);
     }
 
+    /**
+     * Creates a new {@code LazyValueMap} backed by a map created by the specified map factory.
+     *
+     * <p>
+     * This offers full control over the backing map implementation.
+     * For instance:
+     * <pre>{@code
+     * Map<K, V> lazyHashMap = new LazyValueMap<>(HashMap::new);
+     * Map<K, V> lazyLinkedHashMap = new LazyValueMap<>(LinkedHashMap::new);
+     * Map<K, V> lazyTreeMap = new LazyValueMap<>(TreeMap::new);
+     * }</pre>
+     *
+     * <p>
+     * Technically, the mapFactory does not <em>need</em> to create a new map,
+     * but please be aware that sharing the delegate map may cause unexpected behaviour,
+     * especially if it is accessed concurrently.
+     *
+     * @param mapFactory The map factory to provide the backing map (required, must provide a non-{@code null} map).
+     */
     public LazyValueMap(Supplier<Map<K, Lazy<V>>> mapFactory) {
-        this.delegate = mapFactory.get();
+        this.delegate = requireNonNull(mapFactory.get(), "Backing map may not be <null>.");
     }
 
     @Override

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -1,0 +1,221 @@
+package nl.talsmasoftware.lazy4j;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static nl.talsmasoftware.lazy4j.LazyUtils.getIfAvailableElseNull;
+import static nl.talsmasoftware.lazy4j.LazyUtils.getNullSafe;
+
+public class LazyValueMap<K, V> extends AbstractMap<K, V> {
+    private final Map<K, Lazy<V>> delegate;
+
+    public LazyValueMap() {
+        this(LinkedHashMap::new);
+    }
+
+    public LazyValueMap(Map<K, V> toCopy) {
+        this();
+        putAll(toCopy);
+    }
+
+    public LazyValueMap(Supplier<Map<K, Lazy<V>>> mapFactory) {
+        this.delegate = mapFactory.get();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return new LazyEntrySet<>(delegate.entrySet());
+    }
+
+    public Optional<V> getIfAvailable(K key) {
+        return Optional.ofNullable(getIfAvailableElseNull(delegate.get(key)));
+    }
+
+    @Override
+    public V get(Object key) {
+        return getNullSafe(delegate.get(key));
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return getIfAvailableElseNull(putLazy(key, Lazy.eager(value)));
+    }
+
+    public Lazy<V> putLazy(K key, Supplier<V> valueSupplier) {
+        return delegate.put(key, Lazy.of(valueSupplier));
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        // First pass, check available values.
+        List<Lazy<V>> unavailableOnFirstPass = new ArrayList<>();
+        for (Lazy<V> lazyValue : delegate.values()) {
+            if (!lazyValue.isAvailable()) {
+                if (unavailableOnFirstPass != null) {
+                    if (unavailableOnFirstPass.size() < 10000) {
+                        unavailableOnFirstPass.add(lazyValue);
+                    } else { // prevent excessive memory usage.
+                        unavailableOnFirstPass = null;
+                    }
+                }
+            } else if (Objects.equals(value, lazyValue.get())) {
+                return true;
+            }
+        }
+        // Second pass, check the values that were not yet available.
+        for (Lazy<V> lazyValue : unavailableOnFirstPass != null ? unavailableOnFirstPass : delegate.values()) {
+            if (Objects.equals(value, lazyValue.get())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public V remove(Object key) {
+        return getIfAvailableElseNull(delegate.remove(key));
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return delegate.keySet();
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        return getNullSafe(computeIfAbsentLazy(key, mappingFunction));
+    }
+
+    public Lazy<V> computeIfAbsentLazy(K key, Function<? super K, ? extends V> mappingFunction) {
+        return delegate.computeIfAbsent(key, k -> Lazy.of(() -> mappingFunction.apply(k)));
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        return getIfAvailableElseNull(putIfAbsentLazy(key, Lazy.eager(value)));
+    }
+
+    public Lazy<V> putIfAbsentLazy(K key, Supplier<V> value) {
+        return delegate.putIfAbsent(key, Lazy.of(value));
+    }
+
+    @Override
+    public V replace(K key, V value) {
+        return getIfAvailableElseNull(replaceLazy(key, Lazy.eager(value)));
+    }
+
+    public Lazy<V> replaceLazy(K key, Supplier<V> value) {
+        return delegate.replace(key, Lazy.of(value));
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        if (containsKey(key) && Objects.equals(oldValue, get(key))) {
+            put(key, newValue);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return getNullSafe(computeIfPresentLazy(key, remappingFunction));
+    }
+
+    public Lazy<V> computeIfPresentLazy(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return delegate.computeIfPresent(key, (k, v) -> Lazy.of(() -> remappingFunction.apply(k, getNullSafe(v))));
+    }
+
+    @Override
+    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return getNullSafe(computeLazy(key, remappingFunction));
+    }
+
+    public Lazy<V> computeLazy(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return delegate.compute(key, (k, v) -> Lazy.of(() -> remappingFunction.apply(k, getNullSafe(v))));
+    }
+
+    @Override
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return getNullSafe(mergeLazy(key, Lazy.eager(value), remappingFunction));
+    }
+
+    public Lazy<V> mergeLazy(K key, Supplier<V> value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return delegate.merge(key, Lazy.of(value), (v1, v2) -> Lazy.of(() -> remappingFunction.apply(getNullSafe(v1), getNullSafe(v2))));
+    }
+
+    private static class LazyEntrySet<K, V> extends AbstractSet<Entry<K, V>> {
+        private final Set<Entry<K, Lazy<V>>> delegateEntrySet;
+
+        private LazyEntrySet(Set<Entry<K, Lazy<V>>> delegate) {
+            this.delegateEntrySet = delegate;
+        }
+
+        @Override
+        public Iterator<Entry<K, V>> iterator() {
+            final Iterator<Entry<K, Lazy<V>>> iterator = delegateEntrySet.iterator();
+            return new Iterator<>() {
+                @Override
+                public boolean hasNext() {
+                    return iterator.hasNext();
+                }
+
+                @Override
+                public Entry<K, V> next() {
+                    return new LazyEntry<>(iterator.next());
+                }
+
+                @Override
+                public void remove() {
+                    iterator.remove();
+                }
+            };
+        }
+
+        @Override
+        public int size() {
+            return delegateEntrySet.size();
+        }
+    }
+
+    private static final class LazyEntry<K, V> implements Entry<K, V> {
+        private final Entry<K, Lazy<V>> delegateEntry;
+
+        private LazyEntry(Entry<K, Lazy<V>> delegate) {
+            this.delegateEntry = delegate;
+        }
+
+        @Override
+        public K getKey() {
+            return delegateEntry.getKey();
+        }
+
+        @Override
+        public V getValue() {
+            return getNullSafe(delegateEntry.getValue());
+        }
+
+        @Override
+        public V setValue(V value) {
+            return getIfAvailableElseNull(delegateEntry.setValue(Lazy.eager(value)));
+        }
+    }
+
+}

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -491,16 +491,39 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
      * Calculate the hashcode for this map.
      *
      * @return The hashcode for this map.
-     * @implNote To comply with the general {@link Map} contract, unfortunately this involves eagerly
-     * evaluating <strong>all</strong> lazy values currently contained in the map.
+     * @implNote To comply with the general {@link Map} contract,
+     * this involves eagerly evaluating <strong>all</strong> lazy values currently contained in the map.
      */
     @Override
     public int hashCode() {
-        // Calculate hashcode for our entries.
-        // Unfortunately this will involve eagerly evaluating all lazy values.
+        // Calculate hashcode for actual entries, not the delegate's (lazy) entries.
         return super.hashCode();
     }
 
+    /**
+     * Determine equality for this map.
+     *
+     * @param o object to be compared for equality with this map
+     * @return Whether the specified object is another map containing the same mappings as this map.
+     * @implNote To comply with the general {@link Map} contract,
+     * this involves eagerly evaluating lazy values until one is encountered that is not contained in the other map.
+     * Therefore, if the map is found to be equal, <em>all</em> its lazy entries will have been eagerly evaluated.
+     */
+    @Override
+    public boolean equals(Object o) {
+        // Determine equality according to the general contract of Map.
+        return super.equals(o);
+    }
+
+    /**
+     * String representation of this map.
+     *
+     * <p>
+     * All values are represented by their {@link Lazy#toString()} representation.
+     * This prevents unnecessary eager evaluation of values by calling {@code LazyValueMap.toString()}.
+     *
+     * @return Standard map representation of keys and lazy values.
+     */
     @Override
     public String toString() {
         return delegate.toString();

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -243,7 +243,7 @@ public class LazyValueMap<K, V> extends AbstractMap<K, V> {
         @Override
         public Iterator<Entry<K, V>> iterator() {
             final Iterator<Entry<K, Lazy<V>>> iterator = delegateEntrySet.iterator();
-            return new Iterator<>() {
+            return new Iterator<Entry<K, V>>() {
                 @Override
                 public boolean hasNext() {
                     return iterator.hasNext();

--- a/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
+++ b/src/main/java/nl/talsmasoftware/lazy4j/LazyValueMap.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018-2025 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.talsmasoftware.lazy4j;
 
 import java.util.*;

--- a/src/test/java/nl/talsmasoftware/lazy4j/LazyUtilsTest.java
+++ b/src/test/java/nl/talsmasoftware/lazy4j/LazyUtilsTest.java
@@ -17,9 +17,24 @@ package nl.talsmasoftware.lazy4j;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LazyUtilsTest {
+    @Test
+    void verifyUnsupportedConstructor() throws NoSuchMethodException {
+        Constructor<LazyUtils> constructor = LazyUtils.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+
+        assertThatThrownBy(constructor::newInstance)
+                .isInstanceOf(InvocationTargetException.class)
+                .cause()
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
     @Test
     void getNullSafe_null() {
         assertThat(LazyUtils.getNullSafe((Lazy<String>) null)).isNull();

--- a/src/test/java/nl/talsmasoftware/lazy4j/LazyUtilsTest.java
+++ b/src/test/java/nl/talsmasoftware/lazy4j/LazyUtilsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018-2025 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.lazy4j;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LazyUtilsTest {
+    @Test
+    void getNullSafe_null() {
+        assertThat(LazyUtils.getNullSafe((Lazy<String>) null)).isNull();
+    }
+
+    @Test
+    void getNullSafe_lazy() {
+        Lazy<String> lazy = Lazy.of(() -> "test");
+        assertThat(lazy.isAvailable()).isFalse();
+        assertThat(LazyUtils.getNullSafe(lazy)).isEqualTo("test");
+        assertThat(lazy.isAvailable()).isTrue();
+    }
+
+    @Test
+    void getIfAvailableElseNull_null() {
+        assertThat(LazyUtils.getIfAvailableElseNull((Lazy<String>) null)).isNull();
+    }
+
+    @Test
+    void getIfAvailableElseNull_lazy() {
+        Lazy<String> lazy = Lazy.of(() -> "test");
+        assertThat(lazy.isAvailable()).isFalse();
+        assertThat(LazyUtils.getIfAvailableElseNull(lazy)).isNull();
+        assertThat(lazy.isAvailable()).isFalse();
+        lazy.get();
+        assertThat(LazyUtils.getIfAvailableElseNull(lazy)).isEqualTo("test");
+        assertThat(lazy.isAvailable()).isTrue();
+    }
+
+    @Test
+    void getIfAvailableElseNull_eager() {
+        assertThat(LazyUtils.getIfAvailableElseNull(Lazy.eager("test"))).isEqualTo("test");
+    }
+
+}

--- a/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
+++ b/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
@@ -17,8 +17,10 @@ package nl.talsmasoftware.lazy4j;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -589,5 +591,43 @@ class LazyValueMapTest {
         assertThat(newLazy.isAvailable()).isTrue();
         assertThat(previousLazy.isAvailable()).isTrue();
         assertThat(subject.get("key")).isEqualTo("oldValuenewValue");
+    }
+
+    @Test
+    void equals_otherMap() {
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", () -> "value");
+
+        Map<String, String> otherMap = new TreeMap<>();
+        otherMap.put("key", "value");
+
+        assertThat(subject).isEqualTo(otherMap);
+        assertThat(otherMap).isEqualTo(subject);
+        assertThat(subject.getLazy("key").isAvailable()).isTrue();
+    }
+
+    @Test
+    void hashCode_sameAsOtherMaps() {
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", () -> "value");
+
+        Map<String, String> otherMap = new HashMap<>();
+        otherMap.put("key", "value");
+
+        assertThat(subject).hasSameHashCodeAs(otherMap);
+        assertThat(subject.getLazy("key").isAvailable()).isTrue();
+    }
+
+    @Test
+    void toString_lazyValues() {
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", () -> "value");
+
+        assertThat(subject.toString()).isEqualTo("{key=Lazy.unresolved}");
+        assertThat(subject.getLazy("key").isAvailable()).isFalse();
+
+        subject.get("key");
+        assertThat(subject.toString()).isEqualTo("{key=Lazy[value]}");
+        assertThat(subject.getLazy("key").isAvailable()).isTrue();
     }
 }

--- a/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
+++ b/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
@@ -326,11 +326,11 @@ class LazyValueMapTest {
     }
 
     @Test
-    void computeIfAbsentLazy() {
+    void lazyComputeIfAbsent() {
         LazyValueMap<String, String> subject = new LazyValueMap<>();
         AtomicBoolean called = new AtomicBoolean(false);
 
-        subject.computeIfAbsentLazy("key", k -> {
+        subject.lazyComputeIfAbsent("key", k -> {
             called.set(true);
             return "value";
         });
@@ -352,14 +352,14 @@ class LazyValueMapTest {
     }
 
     @Test
-    void putIfAbsentLazy() {
+    void putLazyIfAbsent() {
         LazyValueMap<String, String> subject = new LazyValueMap<>();
         Lazy<String> lazy = Lazy.of(() -> "value");
 
-        assertThat(subject.putIfAbsentLazy("key", lazy)).isNull();
+        assertThat(subject.lazyPutIfAbsent("key", lazy)).isNull();
         assertThat(lazy.isAvailable()).isFalse();
 
-        assertThat(subject.putIfAbsentLazy("key", () -> "other").isAvailable()).isFalse();
+        assertThat(subject.lazyPutIfAbsent("key", () -> "other").isAvailable()).isFalse();
         assertThat(lazy.isAvailable()).isFalse();
 
         assertThat(subject.get("key")).isEqualTo("value");
@@ -383,13 +383,13 @@ class LazyValueMapTest {
     }
 
     @Test
-    void replaceLazy() {
+    void lazyReplace() {
         LazyValueMap<String, String> subject = new LazyValueMap<>();
-        assertThat(subject.replaceLazy("newKey", () -> "other")).isNull();
+        assertThat(subject.lazyReplace("newKey", () -> "other")).isNull();
         assertThat(subject.containsKey("newKey")).isFalse();
 
         subject.putLazy("key", () -> "lazy value");
-        Lazy<String> result = subject.replaceLazy("key", () -> "other value");
+        Lazy<String> result = subject.lazyReplace("key", () -> "other value");
         assertThat(result.isAvailable()).isFalse();
         assertThat(subject.getLazy("key").isAvailable()).isFalse();
 
@@ -425,12 +425,12 @@ class LazyValueMapTest {
     }
 
     @Test
-    void computeIfPresentLazy() {
+    void lazyComputeIfPresent() {
         LazyValueMap<String, String> subject = new LazyValueMap<>();
         AtomicBoolean called = new AtomicBoolean(false);
 
         // not present
-        Lazy<String> result = subject.computeIfPresentLazy("newKey", (k, v) -> {
+        Lazy<String> result = subject.lazyComputeIfPresent("newKey", (k, v) -> {
             called.set(true);
             return v + "other";
         });
@@ -440,7 +440,7 @@ class LazyValueMapTest {
 
         // lazy value
         subject.putLazy("key", () -> "value");
-        result = subject.computeIfPresentLazy("key", (k, v) -> {
+        result = subject.lazyComputeIfPresent("key", (k, v) -> {
             called.set(true);
             return v + "+other";
         });
@@ -485,12 +485,12 @@ class LazyValueMapTest {
     }
 
     @Test
-    void computeLazy() {
+    void lazyCompute() {
         LazyValueMap<String, String> subject = new LazyValueMap<>();
         AtomicBoolean called = new AtomicBoolean(false);
 
         // No existing value
-        Lazy<String> result = subject.computeLazy("newKey", (k, v) -> {
+        Lazy<String> result = subject.lazyCompute("newKey", (k, v) -> {
             called.set(true);
             return v + "+other";
         });
@@ -503,7 +503,7 @@ class LazyValueMapTest {
         // Existing value
         subject.putLazy("key", () -> "value");
         called.set(false);
-        result = subject.computeLazy("key", (k, v) -> {
+        result = subject.lazyCompute("key", (k, v) -> {
             called.set(true);
             return v + "+other";
         });
@@ -545,11 +545,11 @@ class LazyValueMapTest {
     }
 
     @Test
-    void mergeLazy_noExistingValue() {
+    void lazyMerge_noExistingValue() {
         LazyValueMap<String, String> subject = new LazyValueMap<>();
         AtomicBoolean called = new AtomicBoolean(false);
 
-        Lazy<String> result = subject.mergeLazy("newKey", () -> "newValue", (v1, v2) -> {
+        Lazy<String> result = subject.lazyMerge("newKey", () -> "newValue", (v1, v2) -> {
             called.set(true);
             return v1 + v2;
         });
@@ -564,14 +564,14 @@ class LazyValueMapTest {
     }
 
     @Test
-    void mergeLazy_existingLazyValue() {
+    void lazyMergeValue() {
         LazyValueMap<String, String> subject = new LazyValueMap<>();
         AtomicBoolean called = new AtomicBoolean(false);
         Lazy<String> previousLazy = Lazy.of(() -> "oldValue");
         Lazy<String> newLazy = Lazy.of(() -> "newValue");
         subject.putLazy("key", previousLazy);
 
-        Lazy<String> result = subject.mergeLazy("key", newLazy, (v1, v2) -> {
+        Lazy<String> result = subject.lazyMerge("key", newLazy, (v1, v2) -> {
             called.set(true);
             return v1 + v2;
         });

--- a/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
+++ b/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
@@ -251,23 +251,6 @@ class LazyValueMapTest {
     }
 
     @Test
-    void containsValue_firstPassMemoryIsLimited() {
-        LazyValueMap<String, String> subject = new LazyValueMap<>();
-        for (int i = 1; i < 100000; i++) {
-            subject.putLazy("key" + i, () -> "lazy value");
-        }
-        subject.put("eager", "eager value");
-
-        assertThat(subject.containsValue("eager value")).isTrue();
-        for (int i = 1; i < 100000; i++) {
-            assertThat(subject.getLazy("key" + i).isAvailable()).isFalse();
-        }
-
-        assertThat(subject.containsValue("does not occur")).isFalse();
-        subject.lazyValues().stream().forEach(value -> assertThat(value.isAvailable()).isTrue());
-    }
-
-    @Test
     void size_mustMatchBackingMap() {
         Map<String, Lazy<String>> backingMap = new java.util.LinkedHashMap<>();
         LazyValueMap<String, String> subject = new LazyValueMap<>(() -> backingMap);

--- a/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
+++ b/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018-2025 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.lazy4j;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LazyValueMapTest {
+    @Test
+    void entrySet_emptyMap() {
+        assertThat(new LazyValueMap<>().entrySet()).isEmpty();
+    }
+
+    @Test
+    void entrySet_clear() {
+        Lazy<String> lazy = Lazy.of(() -> "test");
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", lazy);
+
+        assertThat(subject.entrySet()).hasSize(1);
+        subject.entrySet().clear();
+
+        assertThat(subject.entrySet()).isEmpty();
+        assertThat(subject.isEmpty());
+        assertThat(lazy.isAvailable()).isFalse();
+    }
+
+    @Test
+    void getIfAvailable_emptyMap() {
+        assertThat(new LazyValueMap<>().getIfAvailable("key")).isEmpty();
+    }
+
+    @Test
+    void getIfAvailable_notYetEvaluated() {
+        Lazy<String> lazy = Lazy.of(() -> "test");
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", lazy);
+
+        assertThat(subject.getIfAvailable("key")).isEmpty();
+        assertThat(lazy.isAvailable()).isFalse();
+    }
+
+    @Test
+    void getIfAvailable_evaluatedValueNull() {
+        Lazy<String> lazy = Lazy.eager(null);
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", lazy);
+
+        assertThat(subject.getIfAvailable("key")).isEmpty();
+        assertThat(lazy.isAvailable()).isTrue();
+    }
+
+    @Test
+    void getIfAvailable() {
+        Lazy<String> lazy = Lazy.of(() -> "test");
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", lazy);
+
+        assertThat(subject.getIfAvailable("key")).isEmpty();
+        assertThat(subject.get("key")).isEqualTo("test");
+        assertThat(subject.getIfAvailable("key")).contains("test");
+        assertThat(lazy.isAvailable()).isTrue();
+    }
+
+    @Test
+    void get_emptyMap() {
+        assertThat(new LazyValueMap<>().get("key")).isNull();
+    }
+
+    @Test
+    void get_notYetEvaluated() {
+        Lazy<String> lazy = Lazy.of(() -> "test");
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", lazy);
+
+        assertThat(subject.get("key")).isEqualTo("test");
+        assertThat(lazy.isAvailable()).isTrue();
+    }
+
+    @Test
+    void put_emptyMap() {
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+
+        String result = subject.put("key", "test");
+        assertThat(result).isNull();
+        assertThat(subject.getIfAvailable("key")).contains("test");
+    }
+
+    @Test
+    void put_existingValueNotYetEvaluated() {
+        Lazy<String> previousLazyValue = Lazy.of(() -> "old");
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.putLazy("key", previousLazyValue);
+
+        String result = subject.put("key", "new");
+        assertThat(result).isNull();
+        assertThat(previousLazyValue.isAvailable()).isFalse();
+        assertThat(subject.getIfAvailable("key")).contains("new");
+    }
+
+    @Test
+    void put_existingValueAlreadyEvaluated() {
+        LazyValueMap<String, String> subject = new LazyValueMap<>();
+        subject.put("key", "old");
+
+        String result = subject.put("key", "new");
+        assertThat(result).isEqualTo("old");
+        assertThat(subject.getIfAvailable("key")).contains("new");
+    }
+
+}

--- a/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
+++ b/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
@@ -17,6 +17,7 @@ package nl.talsmasoftware.lazy4j;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -610,9 +611,11 @@ class LazyValueMapTest {
     void hashCode_sameAsOtherMaps() {
         LazyValueMap<String, String> subject = new LazyValueMap<>();
         subject.putLazy("key", () -> "value");
+        subject.putLazy(null, () -> null);
 
         Map<String, String> otherMap = new HashMap<>();
         otherMap.put("key", "value");
+        otherMap.put(null, null);
 
         assertThat(subject).hasSameHashCodeAs(otherMap);
         assertThat(subject.getLazy("key").isAvailable()).isTrue();
@@ -629,5 +632,46 @@ class LazyValueMapTest {
         subject.get("key");
         assertThat(subject.toString()).isEqualTo("{key=Lazy[value]}");
         assertThat(subject.getLazy("key").isAvailable()).isTrue();
+    }
+
+    @Test
+    void entryHashCode() {
+        LazyValueMap<String, String> lazyMap = new LazyValueMap<>();
+        lazyMap.putLazy("key", () -> "value");
+
+        Map.Entry<String, String> subject = lazyMap.entrySet().iterator().next();
+
+        assertThat(subject.hashCode()).isEqualTo(Collections.singletonMap("key", "value").hashCode());
+    }
+
+    @Test
+    void entryEquals() {
+        LazyValueMap<String, String> lazyMap = new LazyValueMap<>();
+        lazyMap.putLazy("key", () -> "value");
+
+        Map.Entry<String, String> subject = lazyMap.entrySet().iterator().next();
+        Map.Entry<String, String> other = Collections.singletonMap("key", "value").entrySet().iterator().next();
+
+        assertThat(subject).isEqualTo(subject);
+        assertThat(subject).isEqualTo(other);
+        assertThat(other).isEqualTo(subject);
+        assertThat(subject).isNotEqualTo(null);
+        assertThat(subject).isNotEqualTo("key=value");
+        assertThat(subject).isNotEqualTo(Collections.singletonMap("other", "value").entrySet().iterator().next());
+        assertThat(subject).isNotEqualTo(Collections.singletonMap("key", "other").entrySet().iterator().next());
+    }
+
+    @Test
+    void entryToString() {
+        LazyValueMap<String, String> lazyMap = new LazyValueMap<>();
+        lazyMap.putLazy("key", () -> "value");
+
+        // toString unresolved.
+        Map.Entry<String, String> subject = lazyMap.entrySet().iterator().next();
+        assertThat(subject).hasToString("key=Lazy.unresolved");
+
+        // toString resolved.
+        subject.getValue();
+        assertThat(subject).hasToString("key=Lazy[value]");
     }
 }

--- a/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
+++ b/src/test/java/nl/talsmasoftware/lazy4j/LazyValueMapTest.java
@@ -127,43 +127,6 @@ class LazyValueMapTest {
     }
 
     @Test
-    void getIfAvailable_emptyMap() {
-        assertThat(new LazyValueMap<>().getIfAvailable("key")).isEmpty();
-    }
-
-    @Test
-    void getIfAvailable_notYetEvaluated() {
-        Lazy<String> lazy = Lazy.of(() -> "test");
-        LazyValueMap<String, String> subject = new LazyValueMap<>();
-        subject.putLazy("key", lazy);
-
-        assertThat(subject.getIfAvailable("key")).isEmpty();
-        assertThat(lazy.isAvailable()).isFalse();
-    }
-
-    @Test
-    void getIfAvailable_evaluatedValueNull() {
-        Lazy<String> lazy = Lazy.eager(null);
-        LazyValueMap<String, String> subject = new LazyValueMap<>();
-        subject.putLazy("key", lazy);
-
-        assertThat(subject.getIfAvailable("key")).isEmpty();
-        assertThat(lazy.isAvailable()).isTrue();
-    }
-
-    @Test
-    void getIfAvailable() {
-        Lazy<String> lazy = Lazy.of(() -> "test");
-        LazyValueMap<String, String> subject = new LazyValueMap<>();
-        subject.putLazy("key", lazy);
-
-        assertThat(subject.getIfAvailable("key")).isEmpty();
-        assertThat(subject.get("key")).isEqualTo("test");
-        assertThat(subject.getIfAvailable("key")).contains("test");
-        assertThat(lazy.isAvailable()).isTrue();
-    }
-
-    @Test
     void get_emptyMap() {
         assertThat(new LazyValueMap<>().get("key")).isNull();
     }
@@ -184,7 +147,7 @@ class LazyValueMapTest {
 
         String result = subject.put("key", "test");
         assertThat(result).isNull();
-        assertThat(subject.getIfAvailable("key")).contains("test");
+        assertThat(subject.getLazy("key").getIfAvailable()).contains("test");
     }
 
     @Test
@@ -196,7 +159,7 @@ class LazyValueMapTest {
         String result = subject.put("key", "new");
         assertThat(result).isNull();
         assertThat(previousLazyValue.isAvailable()).isFalse();
-        assertThat(subject.getIfAvailable("key")).contains("new");
+        assertThat(subject.getLazy("key").getIfAvailable()).contains("new");
     }
 
     @Test
@@ -206,7 +169,7 @@ class LazyValueMapTest {
 
         String result = subject.put("key", "new");
         assertThat(result).isEqualTo("old");
-        assertThat(subject.getIfAvailable("key")).contains("new");
+        assertThat(subject.getLazy("key").getIfAvailable()).contains("new");
     }
 
     @Test
@@ -217,7 +180,7 @@ class LazyValueMapTest {
         Lazy<String> result = subject.putLazy("key", lazy);
         assertThat(result).isNull();
         assertThat(lazy.isAvailable()).isFalse();
-        assertThat(subject.getIfAvailable("key")).isEmpty();
+        assertThat(subject.getLazy("key").getIfAvailable()).isEmpty();
         assertThat(subject.get("key")).isEqualTo("test");
     }
 


### PR DESCRIPTION
A `Map` that can store its values in a Lazy manner.

This has the advantage that while providing 'standard' Map features,
unused values do not need to be evaluated.

The behaviour of this map depends on the delegate map it was initialized with.  
- If the delegate map is mutable, the lazy map will be mutable as well.
- If the delegate map is sorted, the lazy map will be sorted as well.
- The _default_ and _copy_ constructors create a lazy map that behaves like a `LinkedHashMap`.
- If the backing map does _not_ support `null` values, the lazy map _will_ support them.

This fixes #274 